### PR TITLE
Config: don't save an empty token

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,9 @@ func GetToken() (string, error) {
 	teaModelOut, _ := p.StartReturningModel()
 	modelOut := teaModelOut.(model)
 	token := modelOut.textInput.Value()
+	if token == "" {
+		return "", fmt.Errorf("no token provided")
+	}
 
 	if err := os.MkdirAll(revsPath, 0700); err != nil {
 		return "", err


### PR DESCRIPTION
This fixes a bug where the user could ctrl-c out of entering a token, or enter a blank value, and that would be dutifully saved to disk as the token value. Later invocations of `revs` would try to read the blank token file, then fail because it's invalid.