### PR TITLE
gitignore main binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+/revs


### PR DESCRIPTION
This is only a minor tweak, but helps if the user runs `go build` in this repo. The resulting binary doesn't need to dirty git status.